### PR TITLE
ci: install p11 from source

### DIFF
--- a/docker-build-env/Dockerfile-With-HSM
+++ b/docker-build-env/Dockerfile-With-HSM
@@ -2,10 +2,6 @@ FROM buildenv
 
 # Install MoCOCrW dependencies (except OpenSSL)
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
-        # libp11 engine
-        libengine-pkcs11-openssl \
-        # headers for p11 engine
-        libp11-dev \
         # for pkcs11-tool which we use to create keys in token
         opensc \
         # p11-kit-modules allows loading of libp11 engine without having to edit openssl.cnf
@@ -13,3 +9,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-rec
         # softhsm2: includes both softhsm2-util and libsofthsm2
         softhsm2 \
         && rm -rf /var/lib/apt/lists/*
+
+RUN cd /tmp && \
+    wget https://github.com/OpenSC/libp11/releases/download/libp11-0.4.12/libp11-0.4.12.tar.gz && \
+    tar xvf libp11-0.4.12.tar.gz && \
+    cd libp11-0.4.12 && \
+    ./configure && make -j$(nproc) && make install
+


### PR DESCRIPTION
This is done for preparation to include a patch that supports EC keygen